### PR TITLE
Improve student activity registration system

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Competitive soccer training and interschool matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Basketball skills development and league games",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu", "ava@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore painting, drawing, and mixed media techniques",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["isabella@mergington.edu", "mia@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Theater arts, acting workshops, and school play productions",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["charlotte@mergington.edu", "amelia@mergington.edu"]
+    },
+    "Math Olympiad": {
+        "description": "Advanced math problem solving and competition preparation",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ethan@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Debate Club": {
+        "description": "Public speaking, argumentation, and competitive debate",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["harper@mergington.edu", "benjamin@mergington.edu"]
     }
 }
 
@@ -62,6 +98,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,25 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsList = details.participants
+          .map(
+            (email) =>
+              `<li><span class="participant-email">${email}</span><button class="remove-btn" data-activity="${name}" data-email="${email}" title="Remove ${email}">&times;</button></li>`
+          )
+          .join("");
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            ${details.participants.length > 0
+              ? `<ul class="participants-list">${participantsList}</ul>`
+              : `<p class="no-participants">No participants yet. Be the first to sign up!</p>`
+            }
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +76,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh the activities list to show the new participant
+        activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +95,43 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle participant removal
+  activitiesList.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".remove-btn");
+    if (!btn) return;
+
+    const activity = btn.dataset.activity;
+    const email = btn.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        // Refresh the activities list
+        activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,61 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed #ddd;
+}
+
+.participants-list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0 0;
+}
+
+.participants-list li {
+  padding: 4px 8px;
+  margin: 4px 0;
+  background-color: #e8eaf6;
+  border-radius: 3px;
+  font-size: 14px;
+  color: #1a237e;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  color: #c62828;
+  font-size: 18px;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  border-radius: 3px;
+  transition: background-color 0.2s;
+}
+
+.remove-btn:hover {
+  background-color: #ffcdd2;
+  color: #b71c1c;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #999;
+  margin-top: 6px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,142 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset the in-memory activities database before each test."""
+    original = copy.deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(original)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# --- GET / ---
+
+def test_root_redirects(client):
+    # Arrange — no extra setup needed
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+# --- GET /activities ---
+
+def test_get_activities_returns_all(client):
+    # Arrange
+    expected_activities = set(activities.keys())
+
+    # Act
+    response = client.get("/activities")
+    data = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert set(data.keys()) == expected_activities
+
+
+def test_get_activities_structure(client):
+    # Arrange
+    required_fields = {"description", "schedule", "max_participants", "participants"}
+
+    # Act
+    response = client.get("/activities")
+    data = response.json()
+
+    # Assert
+    for name, details in data.items():
+        assert required_fields.issubset(details.keys()), f"{name} missing fields"
+
+
+# --- POST /activities/{name}/signup ---
+
+def test_signup_success(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email in response.json()["message"]
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_duplicate_is_rejected(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={existing_email}")
+
+    # Assert
+    assert response.status_code == 400
+    assert "already signed up" in response.json()["detail"].lower()
+
+
+def test_signup_activity_not_found(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "test@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+# --- DELETE /activities/{name}/signup ---
+
+def test_unregister_success(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_student_not_found(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "nobody@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_unregister_activity_not_found(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "test@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"


### PR DESCRIPTION
This pull request adds full support for managing participants in school activities, including both sign-up and removal, with updates to the backend API, frontend UI, and automated tests. It introduces new activities, enables users to view and remove participants from activities, and adds comprehensive tests to ensure correct behavior.

**Backend enhancements:**

* Added several new activities (Soccer Team, Basketball Team, Art Club, Drama Club, Math Olympiad, Debate Club) to the `activities` data structure in `app.py`, each with descriptions, schedules, and initial participants.
* Implemented validation to prevent duplicate sign-ups and added a new endpoint (`DELETE /activities/{activity_name}/signup`) to allow unregistering a student from an activity.

**Frontend improvements:**

* Updated the activities list UI to display participants for each activity, along with a "remove" button next to each participant.
* Added logic to handle participant removal via the new API endpoint, updating the UI accordingly after successful removal.
* Refreshed the activities list in the UI after sign-up or removal to reflect changes immediately.
* Enhanced styles for the participants section, including list formatting, remove button styling, and empty state display.

**Testing and configuration:**

* Added a comprehensive test suite (`tests/test_app.py`) to verify activity retrieval, sign-up, duplicate prevention, unregistering, and error handling, with fixtures to reset the in-memory database between tests.
* Updated `pytest.ini` to specify the test paths for running tests.